### PR TITLE
Update prepdocs.ps1

### DIFF
--- a/scripts/prepdocs.ps1
+++ b/scripts/prepdocs.ps1
@@ -9,4 +9,4 @@ foreach ($line in $output) {
 Write-Host "Environment variables set."
 
 pip install -r ./scripts/requirements.txt
-python ./scripts/prepdocs.py '.\data\*' --storageaccount $env:AZURE_STORAGE_ACCOUNT --container $env:AZURE_STORAGE_CONTAINER --searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX -v
+python ./scripts/prepdocs.py './data/*' --storageaccount $env:AZURE_STORAGE_ACCOUNT --container $env:AZURE_STORAGE_CONTAINER --searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX -v


### PR DESCRIPTION
need to switch for pwsh windows forward slash './data/*'  otherwise no data is processed

PS /Users/alexzeltov/git/azure-search-openai-demo> python ./scripts/prepdocs.py '.\data\*' --searchkey "XZnvXI20iBoBfucFfsObjMTvVYXny0txh6n81NvwnGAzSeBUiHAL" --storageaccount $env:AZURE_STORAGE_ACCOUNT --container $env:AZURE_STORAGE_CONTAINER --searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX -v Ensuring search index gptkbindex exists
Search index gptkbindex already exists
Processing files...
PS /Users/alexzeltov/git/azure-search-openai-demo> python ./scripts/prepdocs.py './data/*' --searchkey "XZnvXI20iBoBfucFfsObjMTvVYXny0txh6n81NvwnGAzSeBUiHAL" --storageaccount $env:AZURE_STORAGE_ACCOUNT --container $env:AZURE_STORAGE_CONTAINER --searchservice $env:AZURE_SEARCH_SERVICE --index $env:AZURE_SEARCH_INDEX -v  Ensuring search index gptkbindex exists
Search index gptkbindex already exists
Processing files...
Processing './data/Northwind_Standard_Benefits_Details.pdf'
        Uploading blob for page 0 -> Northwind_Standard_Benefits_Details-0.pdf
        Uploading blob for page 1 -> Northwind_Standard_Benefits_Details-1.pdf

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->